### PR TITLE
cmp/keygen: safe chaincode

### DIFF
--- a/protocols/cmp/keygen/keygen_test.go
+++ b/protocols/cmp/keygen/keygen_test.go
@@ -130,6 +130,7 @@ func checkRefreshConsistence(t *testing.T, oldConfigs map[party.ID]*config.Confi
 		secretKey := group.NewScalar().Set(lagrange[c.ID]).Mul(c.ECDSA)
 		assert.Contains(t, oldConfigs, c.ID)
 		assert.NotEqual(t, c.ECDSA, oldConfigs[c.ID].ECDSA)
+		assert.Equal(t, c.ChainKey, oldConfigs[c.ID].ChainKey)
 		totalECDSANew.Add(secretKey)
 	}
 

--- a/protocols/cmp/keygen/round1.go
+++ b/protocols/cmp/keygen/round1.go
@@ -89,7 +89,7 @@ func (r *round1) Finalize(out chan<- *round.Message) (round.Session, error) {
 
 	// commit to data in message 2
 	SelfCommitment, Decommitment, err := r.HashForID(r.SelfID()).Commit(
-		SelfRID, chainKey, SelfVSSPolynomial, SchnorrRand.Commitment(), ElGamalPublic,
+		SelfRID, SelfVSSPolynomial, SchnorrRand.Commitment(), ElGamalPublic,
 		SelfPedersenPublic.N(), SelfPedersenPublic.S(), SelfPedersenPublic.T())
 	if err != nil {
 		return r, errors.New("failed to commit")


### PR DESCRIPTION
Refactor CMP Keygen process:
- commit chainKey alone
- encrypt chainKey by paillier pubKey and transfer to each peer separately 
- ensure the chainKey doesn't change after key shares refresh